### PR TITLE
Correct handling of multiple MP spends above rank 10

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -279,7 +279,7 @@ class Character < ActiveRecord::Base
         unless debriefs.empty?
             last_game_date = debriefs.joins(:game).where(games: {non_stats: false}).where("games.start_date <= ?", date).maximum("games.start_date") || declared_on
         end
-        monster_point_spends.where("spent_on > ? and spent_on < ?", last_game_date, date).sum(:monster_points_spent)
+        monster_point_spends.where("spent_on > ? and spent_on < ?", last_game_date, date).sum(:character_points_gained)
     end
 
     def monster_points_available_to_spend_on(date, precalculated_character_points = nil, monster_point_spend_to_ignore = nil)

--- a/features/monster_points/spending_monster_points_with_previous_spends.feature
+++ b/features/monster_points/spending_monster_points_with_previous_spends.feature
@@ -23,12 +23,19 @@ Feature: Spending monster points with previous spends
     When the user buys 79 character points for the character
     Then the character should have 100 character points
   
-  Scenario: Can buy up to 30 CP in total for one character in multiple spends if final rank is > 10
-    Given the user has 100 monster points available
-    And the character has 71 character points
-    And the user bought 1 character point for the character yesterday
-    When the user buys 29 character points for the character
-    Then the character should have 101 character points
+  Scenario Outline: Can buy up to 30 CP in total for one character in multiple spends if final rank is > 10
+    # Note that starting MP has to cover previous buy and current buy
+    Given the user has <starting_mp> monster points available
+    And the character has <starting_cp> character points
+    And the user bought <previous_cp_bought> character points for <previous_mp_cost> monster points for the character yesterday
+    When the user buys <cp_bought> character points for the character
+    Then the character should have <final_cp> character points
+    And the user should have <final_mp> monster points
+
+    Examples:
+      | starting_mp | starting_cp | previous_cp_bought | previous_mp_cost | cp_bought | final_cp | final_mp |
+      | 100         | 71          | 1                  | 1                | 29        | 101      | 69       |
+      | 100         | 150         | 4                  | 8                | 26        | 180      | 40       |
   
   Scenario: Cannot buy more than 30 CP in total for one character in multiple spends if final rank is > 10
     Given the user has 100 monster points available

--- a/features/step_definitions/monster_point_spending_steps.rb
+++ b/features/step_definitions/monster_point_spending_steps.rb
@@ -64,6 +64,10 @@ Given(/^the user bought 1 character point for the character yesterday$/) do
   MonsterPointSpendTestHelper.create_monster_point_spend(Character.first, date: Date.yesterday, character_points_gained: 1, monster_points_spent: 1)
 end
 
+Given(/^the user bought (\d+) character points? for (\d+) monster points? for the character yesterday$/) do |cp, mp|
+  MonsterPointSpendTestHelper.create_monster_point_spend(Character.first, date: Date.yesterday, character_points_gained: cp, monster_points_spent: mp)
+end
+
 Given(/^the user bought (\d+) character points? for the character before the game$/) do |points|
   MonsterPointSpendTestHelper.create_monster_point_spend(Character.first, date: Game.first.start_date - 1.day, character_points_gained: points, monster_points_spent: points)
 end


### PR DESCRIPTION
Added additional test scenario for multiple monster point spends over rank 10, and made it pass.

Fixes #98 