### PR TITLE
Character Recycling tests and fixes.

### DIFF
--- a/app/helpers/characters_helper.rb
+++ b/app/helpers/characters_helper.rb
@@ -18,9 +18,9 @@ module CharactersHelper
             if character.user == current_user or current_user.is_character_ref?
                 actions << { :name => "Reactivate", :url => reactivate_character_path(character), :method => :patch } if character.retired?
                 actions << { :name => "Retire", :url => retire_character_path(character), :method => :patch } if character.active?
-                actions << { :name => "Perm-kill", :url => perm_kill_character_path(character), :method => :patch, data: { confirm: "Are you sure you want to permanently kill this character?"} } if character.active? or character.retired?
+                actions << { :name => "Perm-kill", :url => perm_kill_character_path(character), :method => :patch, confirm: "Are you sure you want to permanently kill this character?" } if character.active? or character.retired?
                 actions << { :name => (character.user == current_user ? "Request resurrection from perm-death" : "Resurrect from perm-death"), :url => resurrect_character_path(character), :method => :patch } if character.dead?
-                actions << { :name => "Recycle", :url => recycle_character_path(character), :method => :patch, data: { confirm: "Are you sure you want to recycle this character? This action cannot be undone." } } if character.can_recycle?
+                actions << { :name => "Recycle", :url => recycle_character_path(character), :method => :patch, confirm: "Are you sure you want to recycle this character? This action cannot be undone." } if character.can_recycle?
             end
             if current_user.is_character_ref? and character.approved.nil? and character.user != current_user
                 actions << { :name => "Approve", :url => approve_character_path(character), :method => :patch }

--- a/features/characters/recycle_character.feature
+++ b/features/characters/recycle_character.feature
@@ -1,0 +1,47 @@
+@javascript
+Feature: Recycle character
+  As a player
+  I want to recycle a character for monster points
+  If I've played them a couple of games and not enjoyed the character
+
+  Background:
+    Given there is a user
+    And the user has a character
+    And the user is logged in
+
+  Scenario Outline: Character can be recycled
+    Given the character has played <games> games, earning 10 character points per game
+    And the character has <points> character points before the games
+    When the user recycles the character
+    Then the character should be recycled
+    And the user should have a pending monster point adjustment for <mp_refund> monster points
+
+    Examples:
+      | games | points | mp_refund |
+      | 0     | 21     | 1         |
+      | 1     | 40     | 30        |
+      | 2     | 100    | 100       |
+      | 3     | 170    | 180       |
+
+  Scenario Outline: Character can be recycled with monster point spends
+    Given the character has <start_cp> character points
+    And the character has bought <cp_bought> character points for <mp_spent> monster points
+    When the user recycles the character
+    Then the user should have a pending monster point adjustment for <mp_refund> monster points
+
+    Examples:
+      | start_cp | cp_bought | mp_spent | mp_refund |
+      | 20       | 10        | 10       | 10        |
+      | 100      | 10        | 20       | 100       |
+
+  Scenario: Character can be recycled with multiple monster point spends
+    Given the character has 80 character points
+    And the character has bought 20 character points for 20 monster points
+    And the character has bought 10 character points for 20 monster points
+    When the user recycles the character
+    Then the user should have a pending monster point adjustment for 100 monster points
+
+  Scenario: Character cannot be recycled if they've played 4 or more games
+    Given the character has played 4 games
+    When the user tries to recycle the character
+    Then the user should be unable to recycle the character

--- a/features/model_helpers/game_test_helper.rb
+++ b/features/model_helpers/game_test_helper.rb
@@ -99,8 +99,8 @@ module GameTestHelper
     (Date.today.sunday > Date.today ? Date.today.sunday : Date.today.sunday + 7.days)
   end
 
-  def create_debriefed_game_for_first_character(points)
-    game = create_game(start_date: 14.days.ago)
+  def create_debriefed_game_for_first_character(points, offset = 0)
+    game = create_game(start_date: 14.days.ago + offset.days, title: "New Game #{offset}")
     add_player(Character.first.user, Character.first, to: game)
     debrief(game, player_points: points)
     game

--- a/features/page_models/character_page.rb
+++ b/features/page_models/character_page.rb
@@ -75,6 +75,12 @@ class CharacterPage < BladesDBPage
       end
     end
 
+    def recycle_character
+      accept_confirm do
+        click_link("Recycle")
+      end
+    end
+
     # Checks for Then steps
 
     def check_for_core_fields(character_name: "Testy McTesterson", state: "Active", race: "Human", dts: 10, rank: "2.0")
@@ -154,6 +160,10 @@ class CharacterPage < BladesDBPage
 
     def confirm_absence_of_spend_monster_points_link
         page.find("li#rank").find("div.fieldactions").should have_no_link "Spend monster points" if page.has_selector?("li#rank")
+    end
+
+    def confirm_absence_of_recycle_link
+      page.find("li#state").find("div.fieldactions").should have_no_link "Recycle" if page.has_selector?("li#state")
     end
 
     def check_no_monster_point_spend

--- a/features/step_definitions/character_steps.rb
+++ b/features/step_definitions/character_steps.rb
@@ -78,6 +78,22 @@ Given(/^the user has a character declared one month before the monster spend cut
   CharacterTestHelper.approve_character(User.first)
 end
 
+Given(/^the character has played (\d+) games$/) do |games|
+  games.to_i.times do |offset|
+    GameTestHelper.create_debriefed_game_for_first_character(10, offset)
+  end
+end
+
+Given(/^the character has played (\d+) games, earning (\d+) character points per game$/) do |games, points|
+  games.to_i.times do |offset|
+    GameTestHelper.create_debriefed_game_for_first_character(points.to_i, offset)
+  end
+end
+
+Given(/^the character has bought (\d+) character points for (\d+) monster points$/) do |cp, mp|
+  MonsterPointSpendTestHelper.create_monster_point_spend(Character.first, character_points_gained: cp, monster_points_spent: mp)
+end
+
 # Actions
 
 When(/^the character is at rank (.*?)$/) do |rank|
@@ -204,6 +220,14 @@ When(/^the user gives their character no title$/) do
   CharacterPage.new.visit_page(character_path(1)).and.update_title(no_title: true)
 end
 
+When(/^the user recycles the character$/) do
+  CharacterPage.new.visit_page(character_path(1)).and.recycle_character
+end
+
+When(/^the user tries to recycle the character$/) do
+  CharacterPage.new.visit_page(character_path(1))
+end
+
 # Validations
 
 Then(/^the user should see a short user name and character link on the character$/) do
@@ -259,4 +283,12 @@ end
 
 Then(/^no title should be displayed on the character's profile$/) do
   CharacterPage.new.check_for_character_title(nil)
+end
+
+Then(/^the character should be recycled$/) do
+  CharacterPage.new.visit_page(character_path(1)).and.check_for_state("Recycled")
+end
+
+Then(/^the user should be unable to recycle the character$/) do
+    CharacterPage.new.visit_page(character_path(1)).and.confirm_absence_of_recycle_link
 end

--- a/features/step_definitions/monster_point_adjustment_steps.rb
+++ b/features/step_definitions/monster_point_adjustment_steps.rb
@@ -40,6 +40,11 @@ Then(/^a pending positive monster point adjustment should be created$/) do
   MonsterPointsPage.new.check_for_adjustment(20, state: "provisional")
 end
 
+Then(/^the user should have a pending monster point adjustment for (\d+) monster points$/) do |points|
+  MonsterPointsPage.new.visit_page(monster_points_path).and.check_for_adjustment(points, state: "provisional")
+end
+
+
 Then(/^a pending negative monster point adjustment should be created$/) do
   MonsterPointsPage.new.check_for_adjustment(-20, state: "provisional")
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,14 +31,14 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
- Before do
+  Before do
     Cucumber::Rails::World.use_transactional_fixtures = true
     DatabaseCleaner.strategy = :transaction
   end
- Before('@javascript') do
-   Cucumber::Rails::World.use_transactional_fixtures = false
-   DatabaseCleaner.strategy = :truncation
- end
+  Before('@javascript') do
+    Cucumber::Rails::World.use_transactional_fixtures = false
+    DatabaseCleaner.strategy = :truncation
+  end
   Before do
     DatabaseCleaner.start
     ActiveRecord::FixtureSet.reset_cache  


### PR DESCRIPTION
Added tests for Character Recycling; removed unnecessary CP limit on recycling, and fixed bug where MP spends were not correctly refunded.

Fixes #100 