### PR TITLE
fix: stop free MP allocation on user unsuspend

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
     aasm :column => 'state' do
         state :passive, :initial => true
         state :pending
-        state :active,  :before_enter => :do_activate
+        state :active
         state :suspended
         state :deleted, :before_enter => :do_delete
 
@@ -94,6 +94,9 @@ class User < ApplicationRecord
         end
 
         event :activate do
+            before do
+                do_activate
+            end
             transitions :from => :pending, :to => :active
         end
 

--- a/features/step_definitions/monster_point_spending_steps.rb
+++ b/features/step_definitions/monster_point_spending_steps.rb
@@ -192,6 +192,12 @@ Then(/^the user should have (-?\d+) monster points$/) do |points|
   CharacterPage.new.visit_page("/").and.check_monster_points(points)
 end
 
+Then(/^the other user should have (-?\d+) monster points$/) do |points|
+  BladesDBPage.new.visit_page("/").and.log_out
+  LoginPage.new.visit_page(new_user_session_path).and.login_with_credentials User.last.username, UserTestHelper::DEFAULT_PASSWORD
+  CharacterPage.new.visit_page("/").and.check_monster_points(points)
+end
+
 Then(/^the monster point spend should be deleted$/) do
   CharacterPage.new.visit_page(character_path(Character.first)).and.check_no_monster_point_spend
 end

--- a/features/users/member_list_committee.feature
+++ b/features/users/member_list_committee.feature
@@ -4,26 +4,26 @@ Feature: Member List - Committee
   So I can manage the membership properly
 
   Background:
-  	Given there is a committee user
-  	And the user is logged in
+    Given there is a committee user
+    And the user is logged in
 
   Scenario: All members page - Committee
     Given there is a web-only user
-  	And there is a suspended user
-  	And there is a deleted user
-  	And there is an unconfirmed user
-  	And there is an unapproved user
-  	When the user goes to the members page
+    And there is a suspended user
+    And there is a deleted user
+    And there is an unconfirmed user
+    And there is an unapproved user
+    When the user goes to the members page
     Then the user should be in the Active Members table
     And the other user should be in the Web-only Members table
     And the user should see all other tables
     And the user should see committee user management links
     And the user should not see admin user management links
     And the user should not see a merge users link
-    
+
   Scenario: Accessing other profile
-  	Given there is another user
-  	And the user is on the members page
+    Given there is another user
+    And the user is on the members page
     When the user clicks on the other user's name
     Then the other user's profile should be displayed
 
@@ -39,7 +39,8 @@ Feature: Member List - Committee
     And the user is on the members page
     When the user unsuspends the other user
     Then the other user should be in the Active Members table
-    
+    And the other user should have 80 monster points
+
   Scenario: User deletion
     Given there is another user
     And the user is on the members page


### PR DESCRIPTION
Fixes a bug that causes the free MP allocation intended to be given when a new user is approved to also be given when a suspended user is unsuspended.

Addresses #210.