### PR TITLE
fix: from address on game-related e-mails

### DIFF
--- a/app/controllers/gm_contacts_controller.rb
+++ b/app/controllers/gm_contacts_controller.rb
@@ -9,7 +9,7 @@ class GmContactsController < ApplicationController
 
     def create
         @email = ContactForm.new(email_params)
-        @email.from_user = current_user.email
+        @email.from_user = current_user.name + " <no-reply@bathlarp.co.uk>"
         @email.to_user = @game.gamesmasters.collect(&:email).join(", ")
         @email.subject = "[BathLARP] " + @email.subject
 


### PR DESCRIPTION
Ensure that the domain of the `from` address in e-mails sent by GMs in relation to games is always `bathlarp.co.uk`. This is to reduce the chances of e-mails being blocked due to mismatches between the server and the domain.