### PR TITLE
fix: page titles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
         <%= stylesheet_link_tag 'application', media: 'all' %>
         <%= stylesheet_link_tag 'application', media: 'screen, projection' %>
         <%= stylesheet_link_tag 'application', media: 'print' %>
-        <% if @content_for_title %>
+        <% if content_for?(:title) %>
             <title>BathLARP - <%= yield :title %></title>
         <% else %>
             <title>BathLARP</title>


### PR DESCRIPTION
Use of a deprecated attribute in the top-level layout meant that page titles were not being displayed in the browser title/tab bar. This fixes that.